### PR TITLE
Revert libs path

### DIFF
--- a/src/android/secure-storage.gradle
+++ b/src/android/secure-storage.gradle
@@ -1,7 +1,7 @@
 repositories {
   jcenter()
   flatDir {
-      dirs 'src/main/libs'
+      dirs 'libs'
    }
 }
 


### PR DESCRIPTION
I can't build the Base app with this plugin for Android:
<details>
<summary>Build log</summary>

```
denis@Davidyuk-HP-15:~/projects/aeternity/aepp-identity$ cordova build android
ANDROID_HOME=/home/denis/Android/Sdk
JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
Subproject Path: CordovaLib
Configuration 'compile' in project ':' is deprecated. Use 'implementation' instead.
The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead.
        at build_ecbjz0atesgfv0jc2h6v3w9by.run(/home/denis/projects/aeternity/aepp-identity/platforms/android/build.gradle:142)
publishNonDefault is deprecated and has no effect anymore. All variants are now published.
:preBuild UP-TO-DATE
:CordovaLib:preBuild UP-TO-DATE
:CordovaLib:preDebugBuild UP-TO-DATE
:CordovaLib:checkDebugManifest UP-TO-DATE
:CordovaLib:processDebugManifest UP-TO-DATE
:preDebugBuild FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all files for configuration ':debugCompileClasspath'.
> Could not find :ch-papers-securestorage:.
  Searched in the following locations:
      file:/home/denis/Android/Sdk/extras/m2repository//ch-papers-securestorage//ch-papers-securestorage-.pom
      file:/home/denis/Android/Sdk/extras/m2repository//ch-papers-securestorage//ch-papers-securestorage-.aar
      file:/home/denis/Android/Sdk/extras/google/m2repository//ch-papers-securestorage//ch-papers-securestorage-.pom
      file:/home/denis/Android/Sdk/extras/google/m2repository//ch-papers-securestorage//ch-papers-securestorage-.aar
      file:/home/denis/Android/Sdk/extras/android/m2repository//ch-papers-securestorage//ch-papers-securestorage-.pom
      file:/home/denis/Android/Sdk/extras/android/m2repository//ch-papers-securestorage//ch-papers-securestorage-.aar
      https://jcenter.bintray.com//ch-papers-securestorage//ch-papers-securestorage-.pom
      https://jcenter.bintray.com//ch-papers-securestorage//ch-papers-securestorage-.aar
      https://maven.google.com//ch-papers-securestorage//ch-papers-securestorage-.pom
      https://maven.google.com//ch-papers-securestorage//ch-papers-securestorage-.aar
      file:/home/denis/projects/aeternity/aepp-identity/platforms/android/src/main/libs/ch-papers-securestorage-.aar
      file:/home/denis/projects/aeternity/aepp-identity/platforms/android/src/main/libs/ch-papers-securestorage.aar
  Required by:
      project :

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org

BUILD FAILED in 5s
3 actionable tasks: 1 executed, 2 up-to-date
```

</details>

I have found that it can be fixed by reverting of `dirs` value in "secure-storage.gradle". Last time it was changed in 7729f87fee89228b0af14d14a2a287e5e749fb75, for me it is unclear for what reason.
