### PR TITLE
Android: Fix build errors

### DIFF
--- a/src/android/ch/airgap/securestorage/SecureStorage.java
+++ b/src/android/ch/airgap/securestorage/SecureStorage.java
@@ -44,7 +44,7 @@ public class SecureStorage extends CordovaPlugin {
     return new Storage(this.cordova.getActivity(), alias, isParanoia);
   }
 
-  public boolean execute(String action, JSONArray data, CallbackContext callbackContext) throws JSONException {
+  public boolean execute(String action, JSONArray data, final CallbackContext callbackContext) throws JSONException {
     try {
 
       if (action.equals("initialize")) {

--- a/src/android/ch/airgap/securestorage/SecureStorage.java
+++ b/src/android/ch/airgap/securestorage/SecureStorage.java
@@ -217,7 +217,7 @@ public class SecureStorage extends CordovaPlugin {
         authSuccessCallback.invoke();
         Log.d(TAG, "invoke called");
       } else {
-        Toast.makeText(this.cordova.getContext(), "Authentication failed.", Toast.LENGTH_SHORT).show();
+        Toast.makeText(this.cordova.getActivity(), "Authentication failed.", Toast.LENGTH_SHORT).show();
         authErrorCallback.invoke();
       }
     }


### PR DESCRIPTION
<details>
<summary>Build log: "cannot find getContext symbol" error</summary>

```
denis@Davidyuk-HP-15:~/projects/aeternity/aepp-identity$ npx cordova build android
config file *-Info.plist requested for changes not found at /home/denis/projects/aeternity/aepp-identity/platforms/android/*-Info.plist, ignoring
config file *-Info.plist requested for changes not found at /home/denis/projects/aeternity/aepp-identity/platforms/android/*-Info.plist, ignoring
ANDROID_HOME=/home/denis/Android/Sdk
JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
Subproject Path: CordovaLib
Configuration 'compile' in project ':' is deprecated. Use 'implementation' instead.
The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead.
        at build_ecbjz0atesgfv0jc2h6v3w9by.run(/home/denis/projects/aeternity/aepp-identity/platforms/android/build.gradle:142)
publishNonDefault is deprecated and has no effect anymore. All variants are now published.
:preBuild UP-TO-DATE
:CordovaLib:preBuild UP-TO-DATE
:CordovaLib:preDebugBuild UP-TO-DATE
:CordovaLib:checkDebugManifest UP-TO-DATE
:CordovaLib:processDebugManifest UP-TO-DATE
:preDebugBuild UP-TO-DATE
:CordovaLib:compileDebugAidl UP-TO-DATE
:compileDebugAidl UP-TO-DATE
:CordovaLib:packageDebugRenderscript NO-SOURCE
:compileDebugRenderscript
:checkDebugManifest UP-TO-DATE
:generateDebugBuildConfig UP-TO-DATE
:prepareLintJar UP-TO-DATE
:generateDebugResValues UP-TO-DATE
:generateDebugResources
:CordovaLib:compileDebugRenderscript UP-TO-DATE
:CordovaLib:generateDebugResValues UP-TO-DATE
:CordovaLib:generateDebugResources UP-TO-DATE
:CordovaLib:packageDebugResources UP-TO-DATE
:mergeDebugResources UP-TO-DATE
:createDebugCompatibleScreenManifests UP-TO-DATE
:processDebugManifest UP-TO-DATE
:splitsDiscoveryTaskDebug UP-TO-DATE
:CordovaLib:platformAttrExtractor UP-TO-DATE
:CordovaLib:processDebugResources UP-TO-DATE
:processDebugResources UP-TO-DATE
:generateDebugSources
:CordovaLib:generateDebugBuildConfig UP-TO-DATE
:CordovaLib:prepareLintJar UP-TO-DATE
:CordovaLib:generateDebugSources UP-TO-DATE
:CordovaLib:javaPreCompileDebug UP-TO-DATE
:CordovaLib:compileDebugJavaWithJavac UP-TO-DATE
:CordovaLib:processDebugJavaRes NO-SOURCE
:CordovaLib:transformClassesAndResourcesWithPrepareIntermediateJarsForDebug UP-TO-DATE
:javaPreCompileDebug UP-TO-DATE
:compileDebugJavaWithJavac/home/denis/projects/aeternity/aepp-identity/platforms/android/src/ch/airgap/securestorage/SecureStorage.java:220: error: cannot find symbol
        Toast.makeText(this.cordova.getContext(), "Authentication failed.", Toast.LENGTH_SHORT).show();
                                   ^
  symbol:   method getContext()
  location: variable cordova of type CordovaInterface
1 error
 FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileDebugJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

...
```

</details>

<details>
<summary>Build log: "needs to be declared final" error</summary>

```
denis@Davidyuk-HP-15:~/projects/aeternity/aepp-identity$ npx cordova build android
config file *-Info.plist requested for changes not found at /home/denis/projects/aeternity/aepp-identity/platforms/android/*-Info.plist, ignoring
config file *-Info.plist requested for changes not found at /home/denis/projects/aeternity/aepp-identity/platforms/android/*-Info.plist, ignoring
ANDROID_HOME=/home/denis/Android/Sdk
JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
Subproject Path: CordovaLib
Configuration 'compile' in project ':' is deprecated. Use 'implementation' instead.
The Task.leftShift(Closure) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use Task.doLast(Action) instead.
        at build_ecbjz0atesgfv0jc2h6v3w9by.run(/home/denis/projects/aeternity/aepp-identity/platforms/android/build.gradle:142)
publishNonDefault is deprecated and has no effect anymore. All variants are now published.
:preBuild UP-TO-DATE
:CordovaLib:preBuild UP-TO-DATE
:CordovaLib:preDebugBuild UP-TO-DATE
:CordovaLib:checkDebugManifest UP-TO-DATE
:CordovaLib:processDebugManifest UP-TO-DATE
:preDebugBuild UP-TO-DATE
:CordovaLib:compileDebugAidl UP-TO-DATE
:compileDebugAidl UP-TO-DATE
:CordovaLib:packageDebugRenderscript NO-SOURCE
:compileDebugRenderscript
:checkDebugManifest UP-TO-DATE
:generateDebugBuildConfig UP-TO-DATE
:prepareLintJar UP-TO-DATE
:generateDebugResValues UP-TO-DATE
:generateDebugResources
:CordovaLib:compileDebugRenderscript UP-TO-DATE
:CordovaLib:generateDebugResValues UP-TO-DATE
:CordovaLib:generateDebugResources UP-TO-DATE
:CordovaLib:packageDebugResources UP-TO-DATE
:mergeDebugResources UP-TO-DATE
:createDebugCompatibleScreenManifests UP-TO-DATE
:processDebugManifest UP-TO-DATE
:splitsDiscoveryTaskDebug UP-TO-DATE
:CordovaLib:platformAttrExtractor UP-TO-DATE
:CordovaLib:processDebugResources UP-TO-DATE
:processDebugResources UP-TO-DATE
:generateDebugSources
:CordovaLib:generateDebugBuildConfig UP-TO-DATE
:CordovaLib:prepareLintJar UP-TO-DATE
:CordovaLib:generateDebugSources UP-TO-DATE
:CordovaLib:javaPreCompileDebug UP-TO-DATE
:CordovaLib:compileDebugJavaWithJavac UP-TO-DATE
:CordovaLib:processDebugJavaRes NO-SOURCE
:CordovaLib:transformClassesAndResourcesWithPrepareIntermediateJarsForDebug UP-TO-DATE
:javaPreCompileDebug UP-TO-DATE
:compileDebugJavaWithJavac/home/denis/projects/aeternity/aepp-identity/platforms/android/src/ch/airgap/securestorage/SecureStorage.java:77: error: local variable callbackContext is accessed from within inner class; needs to be declared final
            callbackContext.success(s);
            ^
/home/denis/projects/aeternity/aepp-identity/platforms/android/src/ch/airgap/securestorage/SecureStorage.java:84: error: local variable callbackContext is accessed from within inner class; needs to be declared final
            callbackContext.error(e.toString());
            ^
/home/denis/projects/aeternity/aepp-identity/platforms/android/src/ch/airgap/securestorage/SecureStorage.java:107: error: local variable callbackContext is accessed from within inner class; needs to be declared final
            callbackContext.success();
            ^
/home/denis/projects/aeternity/aepp-identity/platforms/android/src/ch/airgap/securestorage/SecureStorage.java:114: error: local variable callbackContext is accessed from within inner class; needs to be declared final
            callbackContext.error(e.toString());
            ^
/home/denis/projects/aeternity/aepp-identity/platforms/android/src/ch/airgap/securestorage/SecureStorage.java:147: error: local variable callbackContext is accessed from within inner class; needs to be declared final
            callbackContext.success();
            ^
/home/denis/projects/aeternity/aepp-identity/platforms/android/src/ch/airgap/securestorage/SecureStorage.java:154: error: local variable callbackContext is accessed from within inner class; needs to be declared final
            callbackContext.error(e.toString());
            ^
/home/denis/projects/aeternity/aepp-identity/platforms/android/src/ch/airgap/securestorage/SecureStorage.java:178: error: local variable callbackContext is accessed from within inner class; needs to be declared final
            callbackContext.success();
            ^
/home/denis/projects/aeternity/aepp-identity/platforms/android/src/ch/airgap/securestorage/SecureStorage.java:185: error: local variable callbackContext is accessed from within inner class; needs to be declared final
            callbackContext.error(e.toString());
            ^
Note: /home/denis/projects/aeternity/aepp-identity/platforms/android/src/org/apache/cordova/splashscreen/SplashScreen.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
8 errors
 FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileDebugJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

...
```

</details>